### PR TITLE
Set body's height to 100% which is a default behavior in Chrome, but …

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,8 @@
     body {
       display: flex;
       flex-direction: row;
+      height: 100%;
+      margin: 0;
     }
     #legend {
       background: #fff;


### PR DESCRIPTION
…not in Firefox, remove any margin a browser might set on the body to prevent a vertical scrollbar